### PR TITLE
Make Receiver Singleton for better access

### DIFF
--- a/core/src/com/coronadefense/Game.kt
+++ b/core/src/com/coronadefense/Game.kt
@@ -11,7 +11,6 @@ import com.coronadefense.states.menuStates.MainMenuState
 
 class Game : ApplicationAdapter() {
   companion object {
-    val receiver = Receiver(mutableListOf())
     var sprites: SpriteBatch? = null
   }
   private var stateManager: StateManager? = null

--- a/core/src/com/coronadefense/receiver/Receiver.kt
+++ b/core/src/com/coronadefense/receiver/Receiver.kt
@@ -8,36 +8,19 @@ import io.ktor.utils.io.core.*
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 import java.net.InetSocketAddress
 
 private const val PORT_NUMBER: Int = 19001
 private const val SERVER_ADDRESS: String = "35.228.171.73"
 
-@ExperimentalUnsignedTypes
-fun main() {
-  runBlocking {
-    val receiver: Receiver = Receiver(mutableListOf(ReceiverPrinter()))
-    println(receiver.connectAsync())
-  }
-  readLine()
-}
-
 /**
  * Object that connects to the backend and listens to broadcaster sending game information.
- * @param observers List of observers to notify about game changes.
  */
-class Receiver(private val observers: MutableList<IReceiverObserver>) {
+object Receiver {
+  var observer: IReceiverObserver? = null
+
   private val socketBuilder = aSocket(ActorSelectorManager(Dispatchers.IO)).tcp()
   private var socket: Socket? = null
-
-  fun addObserver(observer: IReceiverObserver) {
-    observers += observer
-  }
-
-  fun removeObserver(observer: IReceiverObserver) {
-    observers -= observer
-  }
 
   /**
    * Attempt to connect to backend broadcaster.
@@ -50,7 +33,7 @@ class Receiver(private val observers: MutableList<IReceiverObserver>) {
     val connectionNumber: Long = input.readLong()
 
     GlobalScope.launch(Dispatchers.IO, block = {
-        listen(input)
+      listen(input)
     })
 
     return connectionNumber
@@ -64,32 +47,32 @@ class Receiver(private val observers: MutableList<IReceiverObserver>) {
       val packet: ByteReadPacket = input.readPacket(lengthByte.toUByte().toInt())
       val message: IMessage = getMessageType(byteCode).parse(packet.readBytes())
       notifyObservers(message)
-        if(byteCode==MessageType.END_GAME.byteCode){
-            break
-        }
+      if (byteCode == MessageType.END_GAME.byteCode) {
+        break
+      }
     }
   }
 
   private fun notifyObservers(message: IMessage) {
-    for (observer: IReceiverObserver in this.observers) {
+    observer?.let {
       when (message) {
-          is PingMessage -> observer.handlePingMessage(message = message)
-          is FightRoundMessage -> observer.handleFightRoundMessage(message = message)
-          is GameModeMessage -> observer.handleGameModeMessage(message = message)
-          is InputRoundMessage -> observer.handleInputRoundMessage(message = message)
-          is LobbyModeMessage -> observer.handleLobbyModeMessage(message = message)
-          is EndGameMessage -> observer.handleEndGameMessage(message = message)
-          is HealthUpdateMessage -> observer.handleHealthUpdateMessage(message = message)
-          is MoneyUpdateMessage -> observer.handleMoneyUpdateMessage(message = message)
-          is PlayerCountUpdateMessage -> observer.handlePlayerCountUpdateMessage(message = message)
-          is TowerPositionMessage -> observer.handleTowerPositionMessage(message = message)
-          is TowerRemovedMessage -> observer.handleTowerRemovedMessage(message = message)
-          is AnimationConfirmationMessage -> observer.handleAnimationConfirmationMessage(message = message)
-          is BoardToPathAnimationMessage -> observer.handleBoardToPathAnimationMessage(message = message)
-          is PathToPathAnimationMessage -> observer.handlePathToPathAnimationMessage(message = message)
-          is TowerAnimationMessage -> observer.handleTowerAnimationMessage(message = message)
-          is HealthAnimationMessage -> observer.handleHealthAnimationMessage(message = message)
-          is MoneyAnimationMessage -> observer.handleMoneyAnimationMessage(message = message)
+        is PingMessage -> observer!!.handlePingMessage(message = message)
+        is FightRoundMessage -> observer!!.handleFightRoundMessage(message = message)
+        is GameModeMessage -> observer!!.handleGameModeMessage(message = message)
+        is InputRoundMessage -> observer!!.handleInputRoundMessage(message = message)
+        is LobbyModeMessage -> observer!!.handleLobbyModeMessage(message = message)
+        is EndGameMessage -> observer!!.handleEndGameMessage(message = message)
+        is HealthUpdateMessage -> observer!!.handleHealthUpdateMessage(message = message)
+        is MoneyUpdateMessage -> observer!!.handleMoneyUpdateMessage(message = message)
+        is PlayerCountUpdateMessage -> observer!!.handlePlayerCountUpdateMessage(message = message)
+        is TowerPositionMessage -> observer!!.handleTowerPositionMessage(message = message)
+        is TowerRemovedMessage -> observer!!.handleTowerRemovedMessage(message = message)
+        is AnimationConfirmationMessage -> observer!!.handleAnimationConfirmationMessage(message = message)
+        is BoardToPathAnimationMessage -> observer!!.handleBoardToPathAnimationMessage(message = message)
+        is PathToPathAnimationMessage -> observer!!.handlePathToPathAnimationMessage(message = message)
+        is TowerAnimationMessage -> observer!!.handleTowerAnimationMessage(message = message)
+        is HealthAnimationMessage -> observer!!.handleHealthAnimationMessage(message = message)
+        is MoneyAnimationMessage -> observer!!.handleMoneyAnimationMessage(message = message)
       }
     }
   }

--- a/core/src/com/coronadefense/states/GameObserver.kt
+++ b/core/src/com/coronadefense/states/GameObserver.kt
@@ -3,6 +3,7 @@ package com.coronadefense.states
 import com.coronadefense.Game
 import com.coronadefense.api.ApiClient
 import com.coronadefense.receiver.IReceiverObserver
+import com.coronadefense.receiver.Receiver
 import com.coronadefense.receiver.messages.*
 import com.coronadefense.types.GameStage
 import com.coronadefense.types.gameObjects.Tower
@@ -36,7 +37,7 @@ class GameObserver(
     runBlocking {
       ApiClient.leaveLobbyRequest(lobbyId, accessToken)
     }
-    Game.receiver.removeObserver(this)
+    Receiver.observer = null
   }
 
   override fun handlePingMessage(message: PingMessage) {

--- a/core/src/com/coronadefense/states/menuStates/LobbyListState.kt
+++ b/core/src/com/coronadefense/states/menuStates/LobbyListState.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.*
 import com.badlogic.gdx.scenes.scene2d.InputEvent
 import com.badlogic.gdx.scenes.scene2d.ui.Image
 import com.badlogic.gdx.scenes.scene2d.utils.ClickListener
+import com.coronadefense.receiver.Receiver
 import com.coronadefense.states.GameObserver
 import com.coronadefense.states.InputState
 import com.coronadefense.utils.*
@@ -113,14 +114,14 @@ class LobbyListState(
     var accessToken: Long?
 
     runBlocking {
-      val connectionNumber = Game.receiver.connectAsync()
+      val connectionNumber = Receiver.connectAsync()
       val response = ApiClient.joinLobbyRequest(lobbyToJoinID!!, passwordListener.value, connectionNumber)
       accessToken = response.accessToken
     }
 
     accessToken?.let {
       val gameObserver = GameObserver(lobbyToJoinID!!, nameListener.value, accessToken!!, lobbyToJoinPlayerCount ?: 1)
-      Game.receiver.addObserver(gameObserver)
+      Receiver.observer = gameObserver
       stateManager.set(LobbyState(stateManager, gameObserver))
     }
 


### PR DESCRIPTION
Makes Receiver into a singleton for easier access, and changes it to use a single observer. Removes GameObserver instance from Receiver on game end.